### PR TITLE
Fix file writing that might keep old content.

### DIFF
--- a/src/main/java/de/siegmar/fastcsv/writer/CsvWriter.java
+++ b/src/main/java/de/siegmar/fastcsv/writer/CsvWriter.java
@@ -185,7 +185,7 @@ public final class CsvWriter {
 
     private static Writer newWriter(final Path path, final Charset charset) throws IOException {
         return new OutputStreamWriter(Files.newOutputStream(path, StandardOpenOption.CREATE,
-            StandardOpenOption.WRITE), charset);
+            StandardOpenOption.TRUNCATE_EXISTING), charset);
     }
 
 }


### PR DESCRIPTION
This bug happens when you replace an existing file with a new one whose content length is lower than the old one.

For example:
- Old content: `hello world`
- New content: `master`
- Resulting content: `masterworld`