### PR TITLE
Quoted fields at end of a row are silently dropped (fixes #19).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Java
+*.class
+*.log
+
 # Gradle
 .gradle/
 build/

--- a/src/main/java/de/siegmar/fastcsv/reader/RowReader.java
+++ b/src/main/java/de/siegmar/fastcsv/reader/RowReader.java
@@ -31,6 +31,7 @@ final class RowReader implements Closeable {
     private static final int FIELD_MODE_QUOTED = 1;
     private static final int FIELD_MODE_NON_QUOTED = 2;
     private static final int FIELD_MODE_QUOTE_ON = 4;
+    private static final int FIELD_MODE_QUOTED_EMPTY = 8;
 
     private final Reader reader;
     private final char fieldSeparator;
@@ -79,7 +80,10 @@ final class RowReader implements Closeable {
                     // end of data
                     finished = true;
 
-                    if (localPrevChar == fieldSeparator || localCurrentField.hasContent()) {
+                    if (localPrevChar == fieldSeparator
+                            || (fieldMode & FIELD_MODE_QUOTED_EMPTY) == FIELD_MODE_QUOTED_EMPTY
+                            || localCurrentField.hasContent()
+                    ) {
                         localLine.addField(localCurrentField.toStringAndReset());
                     }
 
@@ -98,6 +102,8 @@ final class RowReader implements Closeable {
                     if (copyLen > 0) {
                         localCurrentField.append(localBuf, localCopyStart, copyLen);
                         copyLen = 0;
+                    } else {
+                        fieldMode |= FIELD_MODE_QUOTED_EMPTY;
                     }
                     localCopyStart = localBufPos;
                 } else {

--- a/src/test/java/de/siegmar/fastcsv/reader/CsvReaderTest.java
+++ b/src/test/java/de/siegmar/fastcsv/reader/CsvReaderTest.java
@@ -177,6 +177,10 @@ public class CsvReaderTest {
         assertEquals(readCsvRow("foo,\"bar \"\"is\"\" ok\"").getField(1), "bar \"is\" ok");
     }
 
+    public void handlesEmptyQuotedFieldsAtEndOfRow() throws IOException {
+        assertEquals(readCsvRow("foo,\"\"").getField(1), "");
+    }
+
     public void dataAfterNewlineAfterEnclosure() throws IOException {
         CsvContainer csv = read("\"foo\"\nbar");
         assertEquals(csv.getRowCount(), 2);


### PR DESCRIPTION
If a field at the end of a row was quoted but empty, it was silently
dropped. For example, take this CSV:

```
"foo",""
```

This would only end up having 1 field in the resulting row instead of
the expected 2. This PR fixes this bug.