### PR TITLE
When doing append, CsvWriter should not open the file with StandardOpenOption.TRUNCATE_EXISTING mode, rather it would use StandardOpenOption.APPEND mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - 2018-11-30
+### Fixed
+- Fix destroying contents of an existing file with CsvWriter.append().
+
 ## [1.0.3] - 2018-10-06
 ### Fixed
 - Fix dropping empty quoted fields [\#19](https://github.com/osiegmar/FastCSV/issues/19)

--- a/README.md
+++ b/README.md
@@ -34,9 +34,16 @@ To add a dependency using Maven, use the following:
 To add a dependency using Gradle:
 
 ```gradle
-dependencies {
-    compile 'de.siegmar:fastcsv:1.0.3'
-}
+	allprojects {
+		repositories {
+			...
+			maven { url 'https://jitpack.io' }
+		}
+	}
+
+	dependencies {
+	        implementation 'com.github.lancewoo:FastCSV:v1.0.4'
+	}
 ```
 
 
@@ -138,6 +145,10 @@ try (CsvAppender csvAppender = csvWriter.append(file, StandardCharsets.UTF_8)) {
     csvAppender.appendField("value3");
     csvAppender.appendField("value4");
     csvAppender.endLine();
+
+    // flush and close
+    csvAppender.flush();
+    csvAppender.close();
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,11 @@ apply plugin: 'findbugs'
 apply plugin: 'checkstyle'
 apply plugin: 'signing'
 apply plugin: 'maven-publish'
+apply plugin: 'maven'
 
 group = "de.siegmar"
 archivesBaseName = "fastcsv"
-version = "1.0.3"
+version = "1.0.4"
 
 sourceCompatibility = 1.7
 

--- a/src/main/java/de/siegmar/fastcsv/writer/CsvWriter.java
+++ b/src/main/java/de/siegmar/fastcsv/writer/CsvWriter.java
@@ -161,7 +161,7 @@ public final class CsvWriter {
      * @throws NullPointerException if path or charset is null
      */
     public CsvAppender append(final Path path, final Charset charset) throws IOException {
-        return append(newWriter(
+        return append(appendWriter(
             Objects.requireNonNull(path, "path must not be null"),
             Objects.requireNonNull(charset, "charset must not be null")
         ));
@@ -186,6 +186,11 @@ public final class CsvWriter {
     private static Writer newWriter(final Path path, final Charset charset) throws IOException {
         return new OutputStreamWriter(Files.newOutputStream(path, StandardOpenOption.CREATE,
             StandardOpenOption.TRUNCATE_EXISTING), charset);
+    }
+
+    private static Writer appendWriter(final Path path, final Charset charset) throws IOException {
+        return new OutputStreamWriter(Files.newOutputStream(path, StandardOpenOption.CREATE,
+            StandardOpenOption.APPEND), charset);
     }
 
 }


### PR DESCRIPTION
When doing append, CsvWriter should not open the file with StandardOpenOption.TRUNCATE_EXISTING mode, rather it would use StandardOpenOption.APPEND mode.

Otherwise, the contents of the existing file would be destroyed.