### PR TITLE
Accept the Appendable interface for output.

### DIFF
--- a/src/test/java/blackbox/writer/CsvWriterTest.java
+++ b/src/test/java/blackbox/writer/CsvWriterTest.java
@@ -221,6 +221,16 @@ public class CsvWriterTest {
     }
 
     @Test
+    public void mixedAppendableUsage() {
+        final StringBuilder stringBuilder = new StringBuilder();
+        final CsvWriter csvWriter = CsvWriter.builder().build(stringBuilder);
+        csvWriter.writeRow("foo", "bar");
+        stringBuilder.append("# my comment\r\n");
+        csvWriter.writeRow("1", "2");
+        assertEquals("foo,bar\r\n# my comment\r\n1,2\r\n", stringBuilder.toString());
+    }
+
+    @Test
     public void unwritableArray() {
         final UncheckedIOException e = assertThrows(UncheckedIOException.class, () ->
             crw.build(new UnwritableWriter()).writeRow("foo"));

--- a/src/test/java/de/siegmar/fastcsv/writer/CachingWriterTest.java
+++ b/src/test/java/de/siegmar/fastcsv/writer/CachingWriterTest.java
@@ -4,16 +4,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class CachingWriterTest {
 
-    private final StringWriter sw = new StringWriter();
-    private final CsvWriter.CachingWriter cw = new CsvWriter.CachingWriter(sw);
-
-    @Test
-    public void appendSingle() throws IOException {
+    @ParameterizedTest
+    @MethodSource("provideArguments")
+    public void appendSingle(final Appendable sw, final CsvWriter.CachingWriter cw) throws IOException {
         final StringBuilder sb = new StringBuilder();
 
         for (int i = 0; i < 8192; i++) {
@@ -26,8 +27,9 @@ public class CachingWriterTest {
         assertEquals(sb.toString(), sw.toString());
     }
 
-    @Test
-    public void appendArray() throws IOException {
+    @ParameterizedTest
+    @MethodSource("provideArguments")
+    public void appendArray(final Appendable sw, final CsvWriter.CachingWriter cw) throws IOException {
         final StringBuilder sb = new StringBuilder();
 
         for (int i = 0; i < 8192; i++) {
@@ -39,8 +41,9 @@ public class CachingWriterTest {
         assertEquals(sb.toString(), sw.toString());
     }
 
-    @Test
-    public void appendLarge() throws IOException {
+    @ParameterizedTest
+    @MethodSource("provideArguments")
+    public void appendLarge(final Appendable sw, final CsvWriter.CachingWriter cw) throws IOException {
         final String sb = buildLargeData();
         cw.write(sb, 0, sb.length());
 
@@ -53,6 +56,17 @@ public class CachingWriterTest {
             sb.append("ab");
         }
         return sb.toString();
+    }
+
+    static Stream<?> provideArguments() {
+        final StringWriter stringWriter = new StringWriter();
+        final CsvWriter.CachingWriter cachingWriterWithStringWriter = new  CsvWriter.CachingWriter(stringWriter);
+
+        final StringBuilder stringBuilder = new StringBuilder();
+        final CsvWriter.CachingWriter cachingWriterWithStringBuilder = new  CsvWriter.CachingWriter(stringBuilder);
+        return Stream.of(
+                Arguments.of(stringWriter, cachingWriterWithStringWriter),
+                Arguments.of(stringBuilder, cachingWriterWithStringBuilder));
     }
 
 }


### PR DESCRIPTION
## Proposed Changes
Accept the Appendable interface for output.
This allows direct use of StringBuilder. For building in-memory CSV data, this simplifies code and avoids the synchronization penalty of StringWriter.

Original public method of CsvWriterBuilder.build(Writer) is retained to ensure binary compatibility with previous versions.

## Performance
Performance seems to have improved, possibly due to the use of `CharBuffer`.

Before:
```
Benchmark                     Mode  Cnt        Score        Error  Units
FastCsvReadBenchmark.read    thrpt   10  1465555.200 ±  50337.767  ops/s
FastCsvWriteBenchmark.write  thrpt   10  1804108.276 ± 160022.167  ops/s
```
After:
```
Benchmark                     Mode  Cnt        Score       Error  Units
FastCsvReadBenchmark.read    thrpt   10  1448338.547 ± 28802.631  ops/s
FastCsvWriteBenchmark.write  thrpt   10  1149119.333 ± 44167.523  ops/s
```