### PR TITLE
Implemented ignoring invalid quote chars - but valid quote chars on last buffer position don't work yet

### DIFF
--- a/src/main/java/de/siegmar/fastcsv/reader/CsvReader.java
+++ b/src/main/java/de/siegmar/fastcsv/reader/CsvReader.java
@@ -44,7 +44,7 @@ public final class CsvReader implements Iterable<CsvRow>, Closeable {
 
     CsvReader(final Reader reader, final char fieldSeparator, final char quoteCharacter,
               final CommentStrategy commentStrategy, final char commentCharacter,
-              final boolean skipEmptyRows, final boolean errorOnDifferentFieldCount) {
+              final boolean skipEmptyRows, final boolean errorOnDifferentFieldCount, final boolean ignoreInvalidQuoteChars) {
 
         assertFields(fieldSeparator, quoteCharacter, commentCharacter);
 
@@ -54,13 +54,13 @@ public final class CsvReader implements Iterable<CsvRow>, Closeable {
         this.reader = reader;
 
         rowReader = new RowReader(reader, fieldSeparator, quoteCharacter, commentStrategy,
-            commentCharacter);
+            commentCharacter, ignoreInvalidQuoteChars);
     }
 
     @SuppressWarnings("PMD.NullAssignment")
     CsvReader(final String data, final char fieldSeparator, final char quoteCharacter,
               final CommentStrategy commentStrategy, final char commentCharacter,
-              final boolean skipEmptyRows, final boolean errorOnDifferentFieldCount) {
+              final boolean skipEmptyRows, final boolean errorOnDifferentFieldCount, final boolean ignoreInvalidQuoteChars) {
 
         assertFields(fieldSeparator, quoteCharacter, commentCharacter);
 
@@ -70,7 +70,7 @@ public final class CsvReader implements Iterable<CsvRow>, Closeable {
         this.reader = null;
 
         rowReader = new RowReader(data, fieldSeparator, quoteCharacter, commentStrategy,
-            commentCharacter);
+            commentCharacter, ignoreInvalidQuoteChars);
     }
 
     private void assertFields(final char fieldSeparator, final char quoteCharacter, final char commentCharacter) {
@@ -243,6 +243,7 @@ public final class CsvReader implements Iterable<CsvRow>, Closeable {
         private char commentCharacter = '#';
         private boolean skipEmptyRows = true;
         private boolean errorOnDifferentFieldCount;
+        private boolean ignoreInvalidQuoteChars = false;
 
         private CsvReaderBuilder() {
         }
@@ -321,6 +322,17 @@ public final class CsvReader implements Iterable<CsvRow>, Closeable {
         }
 
         /**
+         * Defines if invalid placed quote chars like "\"Contains \" in cell content\"" should be ignored.
+         *
+         * @param ignoreInvalidQuoteChars If true invalid placed quote chars will be ignored
+         * @return This updated object, so that additional method calls can be chained together.
+         */
+        public CsvReaderBuilder ignoreInvalidQuoteChars(final boolean ignoreInvalidQuoteChars) {
+            this.ignoreInvalidQuoteChars = ignoreInvalidQuoteChars;
+            return this;
+        }
+
+        /**
          * Constructs a new {@link CsvReader} for the specified arguments.
          * <p>
          * This library uses built-in buffering, so you do not need to pass in a buffered Reader
@@ -378,12 +390,12 @@ public final class CsvReader implements Iterable<CsvRow>, Closeable {
 
         private CsvReader newReader(final Reader reader) {
             return new CsvReader(reader, fieldSeparator, quoteCharacter, commentStrategy,
-                commentCharacter, skipEmptyRows, errorOnDifferentFieldCount);
+                commentCharacter, skipEmptyRows, errorOnDifferentFieldCount, ignoreInvalidQuoteChars);
         }
 
         private CsvReader newReader(final String data) {
             return new CsvReader(data, fieldSeparator, quoteCharacter, commentStrategy,
-                commentCharacter, skipEmptyRows, errorOnDifferentFieldCount);
+                commentCharacter, skipEmptyRows, errorOnDifferentFieldCount, ignoreInvalidQuoteChars);
         }
 
         @Override

--- a/src/main/java/de/siegmar/fastcsv/reader/NamedCsvReader.java
+++ b/src/main/java/de/siegmar/fastcsv/reader/NamedCsvReader.java
@@ -164,6 +164,7 @@ public final class NamedCsvReader implements Iterable<NamedCsvRow>, Closeable {
         private char quoteCharacter = '"';
         private char commentCharacter = '#';
         private boolean skipComments;
+        private boolean ignoreInvalidQuoteChars = false;
 
         private NamedCsvReaderBuilder() {
         }
@@ -211,6 +212,17 @@ public final class NamedCsvReader implements Iterable<NamedCsvRow>, Closeable {
          */
         public NamedCsvReaderBuilder skipComments(final boolean skipComments) {
             this.skipComments = skipComments;
+            return this;
+        }
+
+        /**
+         * Defines if invalid placed quote chars like "\"Contains \" in cell content\"" should be ignored.
+         *
+         * @param ignoreInvalidQuoteChars If true invalid placed quote chars will be ignored
+         * @return This updated object, so that additional method calls can be chained together.
+         */
+        public NamedCsvReaderBuilder ignoreInvalidQuoteChars(final boolean ignoreInvalidQuoteChars) {
+            this.ignoreInvalidQuoteChars = ignoreInvalidQuoteChars;
             return this;
         }
 
@@ -272,7 +284,8 @@ public final class NamedCsvReader implements Iterable<NamedCsvRow>, Closeable {
                 .quoteCharacter(quoteCharacter)
                 .commentCharacter(commentCharacter)
                 .commentStrategy(skipComments ? CommentStrategy.SKIP : CommentStrategy.NONE)
-                .errorOnDifferentFieldCount(true);
+                .errorOnDifferentFieldCount(true)
+                .ignoreInvalidQuoteChars(ignoreInvalidQuoteChars);
         }
 
         @Override


### PR DESCRIPTION
## Fixes

## Proposed Changes

- If ignoreInvalidQuoteChars is set to true invalid quote chars as in `"de:14628:1148:1";"Ri. "Am Windberg"";"51,002455"` are passed to the output (and no exception gets thrown).

## Performance

In order to prevent a performance degradation please run a benchmark
using `./gradlew jmh` before and after your change and show the results.

<!-- Outputs of build/reports/jmh/results.txt -->

Before:
```
Benchmark                     Mode  Cnt        Score        Error  Units
FastCsvReadBenchmark.read    thrpt   10  1987327.151 ± 540067.157  ops/s
FastCsvWriteBenchmark.write  thrpt   10  2841910.312 ±  52620.092  ops/s
```

After:
```
Benchmark                     Mode  Cnt        Score        Error  Units
FastCsvReadBenchmark.read    thrpt   10  2043698.557 ± 126276.985  ops/s
FastCsvWriteBenchmark.write  thrpt   10  2970970.969 ± 261846.346  ops/s
