### PR TITLE
Supplemented JAR manifest with headers required to use library in OSGi environment

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     id("me.champeau.jmh") version "0.7.1"
     id("info.solidsoft.pitest") version "1.9.11"
     id("ru.vyarus.animalsniffer") version "1.7.1"
-    id("biz.aQute.bnd.builder") version "6.4.0"
+    id("biz.aQute.bnd.builder") version "7.0.0"
 }
 
 group = "de.siegmar"
@@ -123,8 +123,8 @@ tasks.jmh {
 tasks.jar {
     manifest {
         attributes("Bundle-SymbolicName" to "de.siegmar.fastcsv",
-                "-exportcontents" to "!de.siegmar.fastcsv.util, *",
-                "-removeheaders" to "Private-Package")
+                   "-exportcontents" to "de.siegmar.fastcsv.reader.*, de.siegmar.fastcsv.writer.*",
+                   "-removeheaders" to "Private-Package")
     }
 }
 

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -123,7 +123,8 @@ tasks.jmh {
 tasks.jar {
     manifest {
         attributes("Bundle-SymbolicName" to "de.siegmar.fastcsv",
-                   "-exportcontents" to "*")
+                "-exportcontents" to "!de.siegmar.fastcsv.util, *",
+                "-removeheaders" to "Private-Package")
     }
 }
 

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     id("me.champeau.jmh") version "0.7.1"
     id("info.solidsoft.pitest") version "1.9.11"
     id("ru.vyarus.animalsniffer") version "1.7.1"
+    id("biz.aQute.bnd.builder") version "6.4.0"
 }
 
 group = "de.siegmar"
@@ -117,6 +118,13 @@ tasks.jmh {
     benchmarkMode = listOf("thrpt")
     fork = 2
     operationsPerInvocation = 1
+}
+
+tasks.jar {
+    manifest {
+        attributes("Bundle-SymbolicName" to "de.siegmar.fastcsv",
+                   "-exportcontents" to "*")
+    }
 }
 
 animalsniffer {


### PR DESCRIPTION
## Proposed Changes

Currently released version of FastCSV library cannot be used in OSGi environment due to lack of required manifest headers - i.e. `MANIFEST.MF` having only the following: 

```
Manifest-Version: 1.0
Automatic-Module-Name: de.siegmar.fastcsv
```

Therefore, `biz.aQute.bnd.builder` gradle plugin was introduced into the project with most basic configuration, and resulting JAR now has all required headers - i.e. `MANIFEST.MF` contains the following: 

```
Manifest-Version: 1.0
Bnd-LastModified: 1696783287923
Bundle-ManifestVersion: 2
Bundle-Name: de.siegmar.fastcsv
Bundle-SymbolicName: de.siegmar.fastcsv
Bundle-Version: 3.0.0.SNAPSHOT
Created-By: 1.8.0_362 (Amazon.com Inc.)
Export-Package: de.siegmar.fastcsv.reader;version="3.0.0",de.siegmar.f
 astcsv.util;version="3.0.0",de.siegmar.fastcsv.writer;version="3.0.0"
Import-Package: de.siegmar.fastcsv.util,java.io,java.lang,java.lang.in
 voke,java.nio,java.nio.channels,java.nio.charset,java.nio.file,java.u
 til,java.util.concurrent.atomic,java.util.function,java.util.stream
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=11))"
Tool: Bnd-6.4.0.202211291949
```

Merging this PR will enable us and others who develop OSGi apps to use FastCSV library out-of-the box (i.e. without additional manual steps, so called wrapping https://bnd.bndtools.org/chapters/390-wrapping.html).

## Performance

(output of `lib/build/results/jmh/results.txt`)

```
Benchmark                     Mode  Cnt        Score        Error  Units
FastCsvReadBenchmark.read    thrpt   10  4080920.655 ± 231511.881  ops/s
FastCsvWriteBenchmark.write  thrpt   10  4540875.096 ±  97908.858  ops/s
```
