### PR TITLE
Suggestion for using bnd plugin for JPMS and OSGi Metadata

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -9,8 +9,9 @@ plugins {
     id("me.champeau.jmh") version "0.7.1"
     id("info.solidsoft.pitest") version "1.9.11"
     id("ru.vyarus.animalsniffer") version "1.7.1"
+    id("biz.aQute.bnd.builder") version "6.4.0"
 }
-
+ 
 group = "de.siegmar"
 version = "3.0.0-SNAPSHOT"
 
@@ -51,6 +52,8 @@ configurations[intTest.implementationConfigurationName].extendsFrom(configuratio
 configurations[intTest.runtimeOnlyConfigurationName].extendsFrom(configurations.testRuntimeOnly.get())
 
 dependencies {
+    compileOnly("org.osgi:org.osgi.annotation.bundle:1.1.0")
+    compileOnly("org.osgi:org.osgi.annotation.versioning:1.1.2")
     commonImplementation("org.assertj:assertj-core:3.24.2")
 
     testImplementation(platform("org.junit:junit-bom:5.9.3"))
@@ -117,6 +120,14 @@ tasks.jmh {
     benchmarkMode = listOf("thrpt")
     fork = 2
     operationsPerInvocation = 1
+}
+
+tasks.jar {
+    manifest {
+        attributes("Bundle-SymbolicName" to "de.siegmar.fastcsv",
+                "-removeheaders" to "Private-Package",
+                "-jpms-module-info" to "")
+    }
 }
 
 animalsniffer {

--- a/lib/src/common/java/module-info.java
+++ b/lib/src/common/java/module-info.java
@@ -1,8 +1,0 @@
-open module common {
-
-    requires de.siegmar.fastcsv;
-    requires org.assertj.core;
-
-    exports testutil;
-
-}

--- a/lib/src/intTest/java/module-info.java
+++ b/lib/src/intTest/java/module-info.java
@@ -1,9 +1,0 @@
-open module blackbox {
-
-    requires common;
-    requires de.siegmar.fastcsv;
-    requires org.junit.jupiter.api;
-    requires org.junit.jupiter.params;
-    requires org.assertj.core;
-
-}

--- a/lib/src/main/java/de/siegmar/fastcsv/reader/package-info.java
+++ b/lib/src/main/java/de/siegmar/fastcsv/reader/package-info.java
@@ -5,4 +5,6 @@
  * and higher level (name/header based) reader via
  * {@link de.siegmar.fastcsv.reader.NamedCsvReader#builder()}.
  */
+@org.osgi.annotation.versioning.Version("2.2.2")
+@org.osgi.annotation.bundle.Export
 package de.siegmar.fastcsv.reader;

--- a/lib/src/main/java/de/siegmar/fastcsv/writer/package-info.java
+++ b/lib/src/main/java/de/siegmar/fastcsv/writer/package-info.java
@@ -3,4 +3,6 @@
  * <p>
  * Obtain writer via {@link de.siegmar.fastcsv.writer.CsvWriter#builder()}.
  */
+@org.osgi.annotation.versioning.Version("2.2.2")
+@org.osgi.annotation.bundle.Export
 package de.siegmar.fastcsv.writer;

--- a/lib/src/main/java/module-info.java
+++ b/lib/src/main/java/module-info.java
@@ -1,9 +1,0 @@
-/**
- * FastCSV
- */
-module de.siegmar.fastcsv {
-
-    exports de.siegmar.fastcsv.reader;
-    exports de.siegmar.fastcsv.writer;
-
-}


### PR DESCRIPTION
As discussed in PR https://github.com/osiegmar/FastCSV/pull/89 here is a Version that takes care of the JPMS stuff.

I have no real clue about gradle, so I only cargo culted that part. Thus there may be more elegent solutions. It also only works for the lib main project and as fas as I can see non of the others.

The Manifest result is:

<img width="392" alt="image" src="https://github.com/osiegmar/FastCSV/assets/8199490/ee5dd1b7-18e2-44dd-9bc2-8448f71331a5">

The Module info now only exists as a compiled class file:

<img width="77" alt="image" src="https://github.com/osiegmar/FastCSV/assets/8199490/e4b2a8c5-ef6b-4234-b71f-ebe0941e6c5a">

But you can see, that it now also references correctly the required java modules for you, which is nice for jlink. You can get fancy with JPMS if you like and use additional Annotations or an instruction: https://bnd.bndtools.org/chapters/330-jpms.html
